### PR TITLE
Fix monitor level settings

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -305,7 +305,6 @@ var
   ShowCheckSection: integer=50;
   ShowExchangeSummary: integer = 1; // 0=Off, 1=Above Field, 2=Status Bar
   AudioDevice: string = '';
-  MonLevel: integer;
 
   Duration: integer = 30;
   Durations: array[0..2] of integer = (30, 7, 60); // 0=Practice, 1=Training, 2=Competition

--- a/Ini.pas
+++ b/Ini.pas
@@ -316,7 +316,7 @@ var
   HiScore: integer;
   CompDuration: integer = 60;
 
-  SelfMonVolume: Integer = 0;
+  MonLevel: Integer = 0;             // Self Monitor Level in dB; range [-60,0]
   SaveWav: boolean = false;
 
 
@@ -538,8 +538,8 @@ begin
       // [Station]
       V := ReadInteger(SEC_STN, 'SelfMonVolume', 0);
       V := max(-60, min(0, V));
-      SelfMonVolume := V;
-      MainForm.VolumeSlider1.Db := SelfMonVolume;
+      MonLevel := V;
+      MainForm.VolumeSlider1.Db := MonLevel;
       SaveWav := ReadBool(SEC_STN, 'SaveWav', SaveWav);
 
       // [Settings]
@@ -664,7 +664,7 @@ begin
       WriteInteger(SEC_TST, 'CompetitionDuration', CompDuration);
 
       // [Station]
-      WriteInteger(SEC_STN, 'SelfMonVolume', SelfMonVolume);
+      WriteInteger(SEC_STN, 'SelfMonVolume', MonLevel);
       WriteBool(SEC_STN, 'SaveWav', SaveWav);
 
       // [Settings]

--- a/Main.pas
+++ b/Main.pas
@@ -2483,7 +2483,7 @@ end;
 }
 procedure TMainForm.VolumeSlider1Change(Sender: TObject);
 begin
-  Ini.SelfMonVolume := round(VolumeSlider1.Db);
+  Ini.MonLevel := round(VolumeSlider1.Db);
 end;
 
 

--- a/Settings.dfm
+++ b/Settings.dfm
@@ -202,8 +202,10 @@ object frmSettings: TfrmSettings
           Top = 48
           Width = 150
           Height = 33
-          Max = 27
-          Frequency = 27
+          LineSize = 3
+          Max = 0
+          Min = -60
+          Frequency = 10
           ShowSelRange = False
           TabOrder = 1
           OnChange = trkBarMonLevelTracking

--- a/Settings.pas
+++ b/Settings.pas
@@ -251,12 +251,8 @@ begin
 end;
 
 procedure TfrmSettings.trkBarMonLevelTracking(Sender: TObject);  // 3dB steps
-var
-  pos: integer;
 begin
-  pos := (trkBarMonLevel.Position*3)-60;
-  if (pos>20) then pos := 20;
-  lblMonLevelNo.Caption := InttoStr(pos);
+  SettgsFuncs.UpdateMonLevelCaption;
   SettgsFuncs.WriteDirtySettingsToRecord(Sender);
 end;
 

--- a/SettingsFuncs.pas
+++ b/SettingsFuncs.pas
@@ -10,8 +10,9 @@ uses inifiles, System.SysUtils, System.Classes, System.StrUtils,
 type
   TSettgsFuncs = class
     procedure LoadSettingsFromIni;
+    procedure UpdateMonLevelCaption;
     procedure LoadAudioComboBox;
-    procedure WriteDirtySettingsToRecord(Sender: TObject);
+    procedure WriteDirtySettingsToRecord(Sender: TObject; AForce: Boolean = false);
     procedure SerialNRCustomRangeClick;
     procedure UpdSerialNR(V: integer);
     procedure UpdSerialNRCustomRange(const ARange: string);
@@ -120,8 +121,8 @@ begin
     trkBarRxBw.Position := round((ini.Bandwidth - 100)/50);
     lblRxBwHzNo.Caption := inttostr(ini.Bandwidth);
 
-    trkBarMonLevel.Position := Round(MainForm.VolumeSlider1.Value*100);
-    lblMonLevelNo.Caption := inttostr(round(80*(MainForm.VolumeSlider1.Value - 0.75)));
+    trkBarMonLevel.Position := Round(MainForm.VolumeSlider1.dB);
+    UpdateMonLevelCaption;
 
     spinSettngActivity.Value := Ini.Activity;
     spinSettngDuration.Value := Ini.Duration;
@@ -135,8 +136,25 @@ begin
     radioSetTrn3CharWrld.Checked := rdoTrain3W;
     radioSetTrn4Char.Checked := rdoTrain4C;
     radioSetTrn5Char.Checked := rdoTrain5C;
+
+    WriteDirtySettingsToRecord(Self, {AForce=}True);
   end;
 end;
+
+procedure TSettgsFuncs.UpdateMonLevelCaption;
+const
+  HintStep : integer = 3;   // Round hint to 3dB steps
+begin
+  var pos: Integer := frmSettings.trkBarMonLevel.Position;
+  var dB : Integer := round(pos/HintStep)*HintStep;
+  if dB >= frmSettings.trkBarMonLevel.Min + HintStep then
+    frmSettings.lblMonLevelNo.Caption := IntToStr(dB)
+  else if pos > frmSettings.trkBarMonLevel.Min then
+    frmSettings.lblMonLevelNo.Caption := IntToStr(pos)
+  else
+    frmSettings.lblMonLevelNo.Caption := 'Off';
+end;
+
 
 procedure TSettgsFuncs.LoadAudioComboBox;
 var
@@ -166,11 +184,11 @@ begin
   end;
 end;
 
-procedure TSettgsFuncs.WriteDirtySettingsToRecord(Sender: TObject);
+procedure TSettgsFuncs.WriteDirtySettingsToRecord(Sender: TObject; AForce: Boolean);
 var
   i : integer;
 begin
-  if frmSettings.Showing then    //suppress writing to record on initial startup
+  if frmSettings.Showing or AForce then    //suppress writing to record on initial startup
   begin                          //when Settings form is hidden
     with SettgsTentv do
     begin
@@ -240,7 +258,7 @@ begin
     CheckBox2.Checked := Ini.Qsb;
     CheckBox5.Checked := Ini.Flutter;
     CheckBox6.Checked := Ini.Lids;
-    // To be done: Mon Level
+    VolumeSlider1.Db := Ini.MonLevel;
     SpinEdit3.Value := Ini.Activity;
   end;
 end;


### PR DESCRIPTION
Fix Monitor Level in settings with main Volume Control

- This change fixes interaction between main Volume Control slider and the new Setting dialog.
- The new Mon. Level slider now uses 60 points between -60 and 0. Each position represents a separate dB level. This was necessary to keep preserve the values handled by the original Mon. Level Volume Control slider.
- Added code to render the MonLevelNo.Caption using 3dB steps.
- The new Mon. Level slider value is written to the original `SelfMonVolume` setting in the `.INI` file.
- Change the Mon. Level hint/caption to render `Off` when the control is slide all the way to the left.
- fixed a bug so this now works. Had to add an argument to `WriteDirtySettingsToRecord` to allow settings to be handled when the dialog is still loading.